### PR TITLE
Improve compilation of MutableArray and MutableReference

### DIFF
--- a/lib/Feldspar/Compiler/Imperative/FromCore/Mutable.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/Mutable.hs
@@ -88,7 +88,9 @@ instance ( Compile dom dom
 
     compileProgSym Return info loc (a :* Nil)
         | MutType UnitType <- infoType info = return ()
-        | otherwise                         = compileProg loc a
+        | otherwise                         = do
+            (e, Bl ds body) <- confiscateBlock $ compileExpr a
+            unless (loc == e) $ tellProg [Block ds body] >> assign loc e
 
     compileProgSym When _ loc (c :* action :* Nil) = do
         c' <- compileExpr c

--- a/lib/Feldspar/Compiler/Imperative/FromCore/MutableToPure.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/MutableToPure.hs
@@ -43,6 +43,7 @@ import Language.Syntactic.Constructs.Binding.HigherOrder
 import Feldspar.Core.Types
 import Feldspar.Core.Interpretation
 import Feldspar.Core.Constructs.Binding
+import Feldspar.Core.Constructs.MutableArray
 import Feldspar.Core.Constructs.MutableToPure
 
 import Feldspar.Compiler.Imperative.Frontend hiding (Type,Variable)
@@ -53,6 +54,7 @@ import Feldspar.Compiler.Imperative.FromCore.Interpretation
 instance ( Compile dom dom
          , Project (CLambda Type) dom
          , Project (Variable :|| Type) dom
+         , Project MutableArray dom
          )
       => Compile MutableToPure dom
   where
@@ -75,6 +77,14 @@ instance ( Compile dom dom
             compileProg var marr
             e <- compileExpr body
             tellProg [copyProg loc e]
+
+    compileProgSym RunMutableArray _ loc ((bnd :$ (na :$ l) :$ (lam :$ body)) :* Nil)
+        | Just (SubConstr2 (Lambda v)) <- prjLambda lam
+        , Just NewArr_ <- prj na
+        = do
+            len <- compileExpr l
+            tellProg [setLength loc len]
+            withAlias v loc $ compileProg loc body
 
     compileProgSym RunMutableArray _ loc (marr :* Nil) = compileProg loc marr
 


### PR DESCRIPTION
Please review these changes. The intention is to improve the result of compilation by reducing the number of variables allocated, as seen in the example below.

```haskell
import Feldspar.Vector.Push as VP

prog :: Vector1 WordN -> Vector1 WordN -> PushVector (Vector1 WordN)
prog = VP.scanl (\a b -> a)
```

`icompile prog` before:
```c
{
    uint32_t v13;
    struct array v2 = {0};
    struct array v4 = {0};
    struct array v9 = {0};

    v13 = getLength(v1);
    initArray(&v2, (0 - sizeof(struct array)), v13);
    initArray(&v4, sizeof(uint32_t), getLength(v0));
    copyArray(&v4, v0);
    for(uint32_t v5 = 0; v5 < v13; v5 += 1)
    {
        initArray(&v9, sizeof(uint32_t), getLength(&v4));
        copyArray(&v9, &v4);
        initArray(&at(struct array,&v2,v5), sizeof(uint32_t), getLength(&v9));
        copyArray(&at(struct array,&v2,v5), &v9);
    }
    initArray(out, (0 - sizeof(struct array)), getLength(&v2));
    copyArray(out, &v2);
    freeArray(&v2);
    freeArray(&v4);
    freeArray(&v9);
}
```

`icompile prog` after:
```c
{
    uint32_t v13;
    struct array v4 = {0};

    v13 = getLength(v1);
    setLength(out, v13);
    initArray(&v4, sizeof(uint32_t), getLength(v0));
    copyArray(&v4, v0);
    for(uint32_t v5 = 0; v5 < v13; v5 += 1)
    {
        initArray(&at(struct array,out,v5), sizeof(uint32_t), getLength(&v4));
        copyArray(&at(struct array,out,v5), &v4);
    }
    freeArray(&v4);
}
```

cc @emilaxelsson, @pjonsson