### PR TITLE
Retire the usage of the VariableRoleAssigner.

### DIFF
--- a/lib/Feldspar/Compiler/Backend/C/Platforms.hs
+++ b/lib/Feldspar/Compiler/Backend/C/Platforms.hs
@@ -308,7 +308,7 @@ traceRules = [rule trace]
          where
             trcVar = Var t trcVarName
             trcVarName = "trc" ++ show i
-            defTrcVar = Def t trcVarName
+            defTrcVar = Def (Variable t trcVarName)
             decl (Bl defs prg) = [replaceWith $ Bl (defs ++ [defTrcVar]) prg]
             trc :: Prog -> [Action (Repr Prog)]
             trc instr = [replaceWith $ Seq [trcVar := val,trcCall,instr]]

--- a/lib/Feldspar/Compiler/Compiler.hs
+++ b/lib/Feldspar/Compiler/Compiler.hs
@@ -198,7 +198,7 @@ pluginChain externalInfo
     . executePlugin RulePlugin (primitivesExternalInfo externalInfo)
     . executePlugin Free ()
     . executePlugin IVarPlugin ()
-    . executePlugin VariableRoleAssigner (variableRoleAssignerExternalInfo externalInfo)
+--    . executePlugin VariableRoleAssigner (variableRoleAssignerExternalInfo externalInfo)
     . executePlugin TypeCorrector (typeCorrectorExternalInfo externalInfo)
     . executePlugin BlockProgramHandler ()
 

--- a/lib/Feldspar/Compiler/Imperative/FromCore/Interpretation.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/Interpretation.hs
@@ -280,8 +280,8 @@ freshVar base t size = do
   return var
 
 declare :: Expr -> CodeWriter ()
-declare (Var t n) = tellDecl [Def t n]
-declare (Ptr t n) = tellDecl [Def t n]
+declare (Var t s) = tellDecl [Def (Variable t s)]
+declare (Ptr t s) = tellDecl [Def (Pointer t s)]
 declare expr      = error $ "declare: cannot declare expression: " ++ show expr
 
 tellDef :: [Ent] -> CodeWriter ()

--- a/lib/Feldspar/Compiler/Imperative/Frontend.hs
+++ b/lib/Feldspar/Compiler/Imperative/Frontend.hs
@@ -125,8 +125,8 @@ instance Monoid Block
     mappend (Bl da pa) (Bl db pb) = Bl (mappend da db) (mappend pa pb)
 
 data Def
-    = Init Type String Expr
-    | Def Type String
+    = Init Var Expr
+    | Def Var
     deriving (Eq,Show)
 
 data Var
@@ -137,8 +137,8 @@ data Var
 class Named a where
     getName :: a -> String
 instance Named Def where
-    getName (Init _ n _) = n
-    getName (Def _ n)    = n
+    getName (Init v _) = getName v
+    getName (Def v)    = getName v
 instance Named Var where
     getName (Variable _ n) = n
     getName (Pointer  _ n) = n
@@ -292,10 +292,10 @@ instance Interface Param where
 
 instance Interface Def where
     type Repr Def = Declaration ()
-    toInterface (Declaration v (Just e) ()) = Init (toInterface $ varType v) (varName v) (toInterface e)
-    toInterface (Declaration v Nothing ()) = Def (toInterface $ varType v) (varName v)
-    fromInterface (Init t s e) = Declaration (AIR.Variable s (fromInterface t) Value ()) (Just $ fromInterface e) ()
-    fromInterface (Def t s) = Declaration (AIR.Variable s (fromInterface t) Value ()) Nothing ()
+    toInterface (Declaration v (Just e) ()) = Init (toInterface v) (toInterface e)
+    toInterface (Declaration v Nothing ()) = Def (toInterface v)
+    fromInterface (Init v e) = Declaration (fromInterface v) (Just $ fromInterface e) ()
+    fromInterface (Def v) = Declaration (fromInterface v) Nothing ()
 
 instance Interface Block where
     type Repr Block = AIR.Block ()


### PR DESCRIPTION
The VariableRoleAssigner analyzes the program to figure out whether
variables are in/out parameters or local to the method. Local variables
are made to be values and composite structures passed in/out are set
as pointers. The information about what goes in/out of the method is
already there in the compiler, so keep that information around.

The code for the VRA is left in the tree for now in case I happened
to break something and we need to reintroduce it.
