### PR TITLE
Retire the BlockProgramHandler.

### DIFF
--- a/lib/Feldspar/Compiler/Compiler.hs
+++ b/lib/Feldspar/Compiler/Compiler.hs
@@ -200,7 +200,7 @@ pluginChain externalInfo
     . executePlugin IVarPlugin ()
 --    . executePlugin VariableRoleAssigner (variableRoleAssignerExternalInfo externalInfo)
     . executePlugin TypeCorrector (typeCorrectorExternalInfo externalInfo)
-    . executePlugin BlockProgramHandler ()
+--    . executePlugin BlockProgramHandler ()
 
 data ExternalInfoCollection = ExternalInfoCollection {
       precompilationExternalInfo          :: ExternalInfo Precompilation

--- a/lib/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore.hs
@@ -99,8 +99,9 @@ compileProgTop funname args a = Mod defs
     outParam = Pointer outType "out"
     outLoc   = Ptr outType "out"
     results  = snd $ evalRWS (compileProg outLoc a) initReader initState
+    decls    = decl results
     Bl ds p  = block results
-    defs     = def results ++ [ProcDf funname ins [outParam] (Block ds p)]
+    defs     = def results ++ [ProcDf funname ins [outParam] (Block (ds ++ decls) p)]
 
 class    SyntacticFeld a => Compilable a internal | a -> internal
 instance SyntacticFeld a => Compilable a ()


### PR DESCRIPTION
We have a WriterMonad at hand; use that infrastructure immediately instead of performing a program transformation at the end when floating variable declarations.

The decision of what declarations that should float and when isn't obvious. The patch has a guard which is currently set to True, but configuration options should come in hand there. The reason I left things that open is that I'm not sure what the configuration options should be. Instead of letting that block  the retirement of the BlockProgramHandler I made a hacky version that mimics the current behavior and allows us to easily change things when we have a better understanding of what we need.
