### PR TITLE
Retire the typedefgenerator plugin.

### DIFF
--- a/lib/Feldspar/Compiler/Compiler.hs
+++ b/lib/Feldspar/Compiler/Compiler.hs
@@ -156,7 +156,7 @@ noMemoryInformation             = defaultOptions { memoryInfoVisible = False }
 pluginChain :: ExternalInfoCollection -> Module () -> Module ()
 pluginChain externalInfo
     = executePlugin RulePlugin (ruleExternalInfo externalInfo)
-    . executePlugin TypeDefinitionGenerator (typeDefinitionGeneratorExternalInfo externalInfo)
+--    . executePlugin TypeDefinitionGenerator (typeDefinitionGeneratorExternalInfo externalInfo)
 --    . executePlugin ConstantFolding ()
     . executePlugin UnrollPlugin (unrollExternalInfo externalInfo)
     . executePlugin Precompilation (precompilationExternalInfo externalInfo)
@@ -193,7 +193,7 @@ executePluginChain' compMode prg originalFunctionSignatureParam opt =
     , typeDefinitionGeneratorExternalInfo = opt
     , variableRoleAssignerExternalInfo    = ()
     , typeCorrectorExternalInfo           = False
-    } $ fromCore (ofn fixedOriginalFunctionSignature) prg
+    } $ fromCore opt (ofn fixedOriginalFunctionSignature) prg
   where
     ofn = NameExtractor.originalFunctionName
     fixedOriginalFunctionSignature = originalFunctionSignatureParam {

--- a/lib/Feldspar/Compiler/Frontend/Interactive/Interface.hs
+++ b/lib/Feldspar/Compiler/Frontend/Interactive/Interface.hs
@@ -106,7 +106,7 @@ icompileWithInfos prg functionName = compileToCCore Interactive prg
                                                           (NameExtractor.OriginalFunctionSignature functionName [])
 
 -- | Get the generated core for a program.
-getCore prog = getCore' prog
+getCore prog = getCore' defaultOptions prog
 
 -- | Print the generated core for a program.
-printCore prog = print $ getCore' prog
+printCore prog = print $ getCore' defaultOptions prog


### PR DESCRIPTION
This patch retires the typedefgenerator plugin. 

It turns out that structs are never created in the frontend and the naming of structs lies deep inside toC in CodeGeneration. Hack around that problem for now by passing around an Options inside the reader monad that we have at our disposal anyways. Long term solution is to untangle the naming from the printing.
