### PR TITLE
Add an entity ValueDef for top level constants and let compileProgTop perform the hoisting of the first literals to the top level.

### DIFF
--- a/lib/Feldspar/Compiler/Backend/C/CodeGeneration.hs
+++ b/lib/Feldspar/Compiler/Backend/C/CodeGeneration.hs
@@ -68,6 +68,7 @@ instance CodeGen (Entity ())
     cgen env TypeDef{..}   = text "typedef" <+> cgen env actualType <+> text typeName <> semi
     cgen env ProcDef{..}   = text "void"    <+> text procName      <>  parens (cgenList (newPlace env MainParameter_pl) $ inParams ++ outParams) $$ block (cgen env procBody)
     cgen env ProcDecl{..}  = text "void"    <+> text procName      <>  parens (cgenList (newPlace env MainParameter_pl) $ inParams ++ outParams) <> semi
+    cgen env ValueDef{..}  = cgen env valVar <+> text " = "         <+> cgen (newPlace env ValueNeed_pl) valValue <> semi
 
     cgenList env = vcat . punctuate (text "\n") . map (cgen env)
 

--- a/lib/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore.hs
@@ -50,11 +50,12 @@ import Language.Syntactic.Constructs.Binding.HigherOrder
 import Feldspar.Core.Types
 import Feldspar.Core.Interpretation
 import Feldspar.Core.Constructs
+import Feldspar.Core.Constructs.Literal
 import Feldspar.Core.Constructs.Binding
 import Feldspar.Core.Frontend
 
 import Feldspar.Compiler.Imperative.Representation as Rep (Module, Expression(..), Variable(..), VariableRole(..))
-import Feldspar.Compiler.Imperative.Representation (Program(..), Block(..), Module(..), Entity(..))
+import Feldspar.Compiler.Imperative.Representation (ActualParameter(..), Program(..), Block(..), Module(..), Entity(..))
 import Feldspar.Compiler.Imperative.Frontend
 import Feldspar.Compiler.Imperative.FromCore.Interpretation
 import Feldspar.Compiler.Imperative.FromCore.Array ()
@@ -88,9 +89,14 @@ instance Compile Empty dom
     compileProgSym _ = error "Can't compile Empty"
     compileExprSym _ = error "Can't compile Empty"
 
-compileProgTop :: (Compile dom dom, Project (CLambda Type) dom) =>
-    Options -> String -> [((VarId,Rep.Expression ()),Rep.Variable ())] -> ASTF (Decor Info dom) a -> Module ()
-compileProgTop opt funname args (lam :$ body)
+compileProgTop :: ( Compile dom dom
+                  , Project (CLambda Type) dom
+                  , Project (Let :|| Type) dom
+                  , Project (Literal :|| Type) dom
+                  ) =>
+    Options -> String -> [((VarId,Rep.Expression ()),Rep.Variable ())] ->
+    [Entity ()] -> ASTF (Decor Info dom) a -> Module ()
+compileProgTop opt funname args ents (lam :$ body)
     | Just (SubConstr2 (Lambda v)) <- prjLambda lam
     = let ta  = argType $ infoType $ getInfo lam
           sa  = defaultSize ta
@@ -98,8 +104,22 @@ compileProgTop opt funname args (lam :$ body)
           arg = if isComposite typ
                   then ((v, mkRef typ v), mkPointer  typ v)
                   else ((v, mkVar typ v), mkVariable typ v)
-       in compileProgTop opt funname (arg:args) body
-compileProgTop opt funname args a = Module defs
+       in compileProgTop opt funname (arg:args) ents body
+compileProgTop opt funname args ents (lt :$ e :$ (lam :$ body))
+  | Just (SubConstr2 (Lambda v)) <- prjLambda lam
+  , Just (C' Let) <- prjF lt
+  , Just (C' Literal{}) <- prjF e -- Input on form let x = n in e
+  , [ProcedureCall "copy" [Out (VarExpr vr), In (ConstExpr c)]] <- bd
+  , freshName <- varName vr -- Ensure that compiled result is on form x = n
+  = compileProgTop opt funname args (ValueDef var c:ents) body
+  where
+    info     = getInfo e
+    outType  = compileTypeRep (infoType info) (infoSize info)
+    var@(Rep.Variable _ _ freshName) = case prjLambda lam of
+               Just (SubConstr2 (Lambda v)) -> mkVariable outType v
+    bd = sequenceProgs $ blockBody $ block $ snd $
+          evalRWS (compileProg (varToExpr var) e) (initReader opt) initState
+compileProgTop opt funname args ents a = Module defs
   where
     ins      = map snd $ reverse args
     info     = getInfo a
@@ -110,16 +130,16 @@ compileProgTop opt funname args a = Module defs
     decls    = decl results
     post     = epilogue results
     Block ds p = block results
-    defs     = (nub $ def results) ++ [ProcDef funname ins [outParam] (Block (ds ++ decls) (Sequence (p:post)))]
+    defs     = reverse ents ++ (nub $ def results) ++ [ProcDef funname ins [outParam] (Block (ds ++ decls) (Sequence (p:post)))]
 
 fromCore :: SyntacticFeld a => Options -> String -> a -> Module ()
 fromCore opt funname
-    = compileProgTop opt funname []
+    = compileProgTop opt funname [] []
     . reifyFeld defaultFeldOpts N32
 
 -- | Get the generated core for a program.
 getCore' :: SyntacticFeld a => Options -> a -> Module ()
-getCore' opts prog = compileProgTop opts "test" [] (reifyFeld defaultFeldOpts N32 prog)
+getCore' opts prog = compileProgTop opts "test" [] [] (reifyFeld defaultFeldOpts N32 prog)
 
 -- | Create a list where each element represents the number of variables needed
 -- to as arguments

--- a/lib/Feldspar/Compiler/Imperative/Representation.hs
+++ b/lib/Feldspar/Compiler/Imperative/Representation.hs
@@ -71,6 +71,10 @@ data Entity t
         , outParams                 :: [Variable t]
         , procBody                  :: Block t
         }
+    | ValueDef
+        { valVar                    :: Variable t
+        , valValue                  :: Constant t
+        }
     | ProcDecl
         { procName                  :: String
         , inParams                  :: [Variable t]

--- a/lib/Feldspar/Compiler/Imperative/TransformationInstance.hs
+++ b/lib/Feldspar/Compiler/Imperative/TransformationInstance.hs
@@ -52,7 +52,7 @@ instance (Transformable1 t [] Entity)
         defaultTransform t s d (Module m) = Result (Module (result1 tr)) (state1 tr) (up1 tr) where
             tr = transform1 t s d m
 
-instance (Transformable1 t [] StructMember, Transformable1 t [] Variable, Transformable t Block, Transformable t Declaration, Combine (Up t), Default (Up t))
+instance (Transformable1 t [] StructMember, Transformable1 t [] Variable, Transformable t Block, Transformable t Declaration, Transformable t Constant, Combine (Up t), Default (Up t))
     => DefaultTransformable t Entity where
         defaultTransform t s d (StructDef n m) =
             Result (StructDef n (result1 tr)) (state1 tr) (up1 tr) where
@@ -70,6 +70,10 @@ instance (Transformable1 t [] StructMember, Transformable1 t [] Variable, Transf
                    (state1 tr2) (foldl1 combine [up1 tr1, up1 tr2]) where
                 tr1 = transform1 t s d inp
                 tr2 = transform1 t (state1 tr1) d outp
+        defaultTransform t s d (ValueDef var val) =
+            Result (ValueDef (result tr1) (result tr2)) (state tr2) (combine (up tr1) (up tr2)) where
+                tr1 = transform t s d var
+                tr2 = transform t (state tr1) d val
 
 instance (Default (Up t))
     => DefaultTransformable t StructMember where


### PR DESCRIPTION
Anders mentioned that it might be possible to relax the hoisting preconditions in syntactic to allow pure computations to float around more freely. This is a stab at implementing the compiler bits of that. I'm not sure about the prettyprinter bits of the patch, but it works for this test case:

``` haskell
cexp11 :: Data Bool -> Data WordN
cexp11 b = share (3 :: Data WordN) $ \x -> b ? x $ 0
```

There's definitely room for improvement in the beauty of the matching code in compileProgTop.
