### PR TITLE
Add an option for configuring indentation size in the pretty printer.

### DIFF
--- a/lib/Feldspar/Compiler/Backend/C/Options.hs
+++ b/lib/Feldspar/Compiler/Backend/C/Options.hs
@@ -48,6 +48,7 @@ data Options =
     , debug             :: DebugOption
     , memoryInfoVisible :: Bool
     , rules             :: [Rule]
+    , nestSize          :: Int -- ^ Indentation size for PrettyPrinting
     } deriving (Eq, Show)
 
 data UnrollStrategy = NoUnroll | Unroll Int

--- a/lib/Feldspar/Compiler/Compiler.hs
+++ b/lib/Feldspar/Compiler/Compiler.hs
@@ -136,6 +136,7 @@ defaultOptions
     , debug             = NoDebug
     , memoryInfoVisible = True
     , rules             = []
+    , nestSize          = 2
     }
 
 c99PlatformOptions :: Options


### PR DESCRIPTION
I find it really hard to see the difference between different indentation levels in an xterm after the new PrettyPrinter code went in. This patch allows me to use the full width of my 80 column xterm!
