### PR TITLE
Fix native array accesses

### DIFF
--- a/lib/Feldspar/Compiler/Backend/C/CodeGeneration.hs
+++ b/lib/Feldspar/Compiler/Backend/C/CodeGeneration.hs
@@ -162,7 +162,7 @@ instance CodeGen (Expression ())
                    (AddressNeed_pl, _) -> text "&"
                    (_, ArrayType _ _)  -> text "&" -- TODO the call site should set the place to AddressNeed_pl for Arrays
                    _                   -> empty
-    cgen env e@NativeElem{..} = prefix <> cgen (newPlace env AddressNeed_pl) array <> brackets (cgen (newPlace env ValueNeed_pl) arrayIndex)
+    cgen env e@NativeElem{..} = prefix <> cgen (newPlace env ValueNeed_pl) array <> brackets (cgen (newPlace env ValueNeed_pl) arrayIndex)
       where
         prefix = case (place env, typeof e) of
                    (AddressNeed_pl, _) -> text "&"


### PR DESCRIPTION
For the variable "uint32_t v258[8]" the write-accesses are on the form "&v258[1] = ..". Make it "v258[1] = .." instead. 
