### PR TITLE
Fixup after varrole-breakage.

### DIFF
--- a/lib/Feldspar/Compiler/Imperative/Frontend.hs
+++ b/lib/Feldspar/Compiler/Imperative/Frontend.hs
@@ -84,9 +84,10 @@ initArray arr len = call "initArray" [Out arr, In s, In len]
     s
         | isArray t = FunctionCall (Function "-" (NumType Unsigned S32) Infix) [litI (NumType Unsigned S32) 0,SizeOf (Left t)]
         | otherwise = SizeOf (Left t)
-    t = case typeof arr of
-        ArrayType _ e -> e
-        _       -> error $ "Feldspar.Compiler.Imperative.Frontend.initArray: invalid type of array " ++ show arr ++ "::" ++ show (typeof arr)
+    t = go $ typeof arr
+    go (ArrayType _ e) = e
+    go (Pointer t) = go t
+    go _               = error $ "Feldspar.Compiler.Imperative.Frontend.initArray: invalid type of array " ++ show arr ++ "::" ++ show (typeof arr)
 
 assignProg :: Expression () -> Expression () -> Program ()
 assignProg inExp outExp = copyProg inExp [outExp]
@@ -186,6 +187,7 @@ litI32 n = litI (NumType Unsigned S32) n
 
 isArray :: Type -> Bool
 isArray ArrayType{} = True
+isArray (Pointer t) = isArray t
 isArray _ = False
 
 isIVar :: Type -> Bool

--- a/lib/Feldspar/Compiler/Imperative/Representation.hs
+++ b/lib/Feldspar/Compiler/Imperative/Representation.hs
@@ -305,12 +305,14 @@ instance HasType (Expression t) where
       where
         decrArrayDepth :: Type -> Type
         decrArrayDepth (ArrayType _ t) = t
+        decrArrayDepth (Pointer t)     = decrArrayDepth t
         decrArrayDepth t               = reprError InternalError $ "Non-array variable is indexed! " ++ show array ++ " :: " ++ show t
     typeof NativeElem{..} = decrArrayDepth $ typeof array
       where
         decrArrayDepth :: Type -> Type
         decrArrayDepth (ArrayType _ t) = t
         decrArrayDepth (NativeArray _ t) = t
+        decrArrayDepth (Pointer t)     = decrArrayDepth t
         decrArrayDepth t               = reprError InternalError $ "Non-array variable is indexed! " ++ show array ++ " :: " ++ show t
     typeof StructField{..} = getStructFieldType fieldName $ typeof struct
       where


### PR DESCRIPTION
Something in the last spur of patches made the retirement of VarRole immediately break the compiler on my code. Not sure why this wasn't triggered when I tested the Pointer changes before requesting the pull.
