### PR TITLE
Retire the NativeElem constructor.

### DIFF
--- a/lib/Feldspar/Compiler/Backend/C/CodeGeneration.hs
+++ b/lib/Feldspar/Compiler/Backend/C/CodeGeneration.hs
@@ -145,12 +145,12 @@ instance CodeGen (ActualParameter ())
 instance CodeGen (Expression ())
   where
     cgen env VarExpr{..} = cgen env var
-    cgen env e@ArrayElem{..}  =  text "at"
-                             <> parens (hcat $ punctuate comma [ cgen env $ typeof e
+    cgen env e@ArrayElem{..}
+     | NativeArray{} <- typeof array = cgen env array <> brackets (cgen env arrayIndex)
+     | otherwise = text "at" <> parens (hcat $ punctuate comma [ cgen env $ typeof e
                                                                , cgen env array
                                                                , cgen env arrayIndex
                                                                ])
-    cgen env e@NativeElem{..} = cgen env array <> brackets (cgen env arrayIndex)
     cgen env e@StructField{..} = parens (cgen env struct) <> char '.' <> text fieldName
     cgen env ConstExpr{..} = cgen env constExpr
     cgen env FunctionCall{..} | funName function == "!"   = call (text "at") $ map (cgen env) funCallParams

--- a/lib/Feldspar/Compiler/Backend/C/Platforms.hs
+++ b/lib/Feldspar/Compiler/Backend/C/Platforms.hs
@@ -139,7 +139,7 @@ nativeArrayRules = [rule toNativeExpr, rule toNativeProg, rule toNativeVariable]
   where
     toNativeExpr :: Expression () -> [Action (Expression ())]
     toNativeExpr (ArrayElem arr ix)
-      | native (typeof arr) = [replaceWith $ NativeElem arr' ix]
+      | native (typeof arr) = [replaceWith $ ArrayElem arr' ix]
       where arr' | AddrOf{} <- arr = addrExpr arr
                  | otherwise       = arr
     toNativeExpr _ = []

--- a/lib/Feldspar/Compiler/Imperative/Representation.hs
+++ b/lib/Feldspar/Compiler/Imperative/Representation.hs
@@ -172,10 +172,6 @@ data Expression t
         { array                     :: Expression t
         , arrayIndex                :: Expression t
         }
-    | NativeElem
-        { array                     :: Expression t
-        , arrayIndex                :: Expression t
-        }
     | StructField
         { struct                    :: Expression t
         , fieldName                 :: String
@@ -299,16 +295,10 @@ instance HasType (Expression t) where
     typeof ArrayElem{..} = decrArrayDepth $ typeof array
       where
         decrArrayDepth :: Type -> Type
-        decrArrayDepth (ArrayType _ t) = t
-        decrArrayDepth (Pointer t)     = decrArrayDepth t
-        decrArrayDepth t               = reprError InternalError $ "Non-array variable is indexed! " ++ show array ++ " :: " ++ show t
-    typeof NativeElem{..} = decrArrayDepth $ typeof array
-      where
-        decrArrayDepth :: Type -> Type
-        decrArrayDepth (ArrayType _ t) = t
+        decrArrayDepth (ArrayType _ t)   = t
         decrArrayDepth (NativeArray _ t) = t
-        decrArrayDepth (Pointer t)     = decrArrayDepth t
-        decrArrayDepth t               = reprError InternalError $ "Non-array variable is indexed! " ++ show array ++ " :: " ++ show t
+        decrArrayDepth (Pointer t)       = decrArrayDepth t
+        decrArrayDepth t                 = reprError InternalError $ "Non-array variable is indexed! " ++ show array ++ " :: " ++ show t
     typeof StructField{..} = getStructFieldType fieldName $ typeof struct
       where
         getStructFieldType :: String -> Type -> Type

--- a/lib/Feldspar/Compiler/Imperative/TransformationInstance.hs
+++ b/lib/Feldspar/Compiler/Imperative/TransformationInstance.hs
@@ -140,9 +140,6 @@ instance (Transformable t Expression, Transformable t Variable, Transformable t 
         defaultTransform t s d (ArrayElem a i) = Result (ArrayElem (result tr1) (result tr2)) (state tr2) (combine (up tr1) (up tr2)) where
             tr1 = transform t s d a
             tr2 = transform t (state tr1) d i
-        defaultTransform t s d (NativeElem a i) = Result (NativeElem (result tr1) (result tr2)) (state tr2) (combine (up tr1) (up tr2)) where
-            tr1 = transform t s d a
-            tr2 = transform t (state tr1) d i
         defaultTransform t s d (StructField l n) = Result (StructField (result tr) n) (state tr) (up tr) where
             tr = transform t s d l
         defaultTransform t s d (ConstExpr c) = Result (ConstExpr (result tr)) (state tr) (up tr) where


### PR DESCRIPTION
We have two different constructors for accessing array elements on different types of arrays, and as expected there's code duplication. Eliminate one of them.
