### PR TITLE
Unify In/Out to the single ValueParameter in ActualParameter.

### DIFF
--- a/lib/Feldspar/Compiler/Backend/C/CodeGeneration.hs
+++ b/lib/Feldspar/Compiler/Backend/C/CodeGeneration.hs
@@ -138,8 +138,7 @@ instance CodeGen (Pattern ())
 
 instance CodeGen (ActualParameter ())
   where
-    cgen env In{..}                  = cgen env inParam
-    cgen env Out{..}                 = cgen env outParam
+    cgen env ValueParameter{..}      = cgen env valueParam
     cgen env TypeParameter{..}       = cgen env typeParam
     cgen env FunParameter{..}        = text funParamName
     cgenList env = hsep . punctuate comma . map (cgen env)

--- a/lib/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore.hs
@@ -114,7 +114,7 @@ compileProgTop opt funname bs (lt :$ e :$ (lam :$ body))
   | Just (SubConstr2 (Lambda v)) <- prjLambda lam
   , Just Let <- prj lt
   , Just (C' Literal{}) <- prjF e -- Input on form let x = n in e
-  , [ProcedureCall "copy" [Out (VarExpr vr), In (ConstExpr c)]] <- bd
+  , [ProcedureCall "copy" [ValueParameter (VarExpr vr), ValueParameter (ConstExpr c)]] <- bd
   , freshName Prelude.== vName vr -- Ensure that compiled result is on form x = n
   = do tellDef [ValueDef var c]
        withAlias v (varToExpr var) $

--- a/lib/Feldspar/Compiler/Imperative/FromCore/Error.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/Error.hs
@@ -67,6 +67,6 @@ compileAssert :: (Compile dom dom)
               => ASTF (Decor Info dom) a -> String -> CodeWriter ()
 compileAssert cond msg = do
     condExpr <- compileExpr cond
-    tellProg [call "assert" [In condExpr]]
+    tellProg [call "assert" [ValueParameter condExpr]]
     unless (null msg) $ tellProg [Comment False $ "{" ++ msg ++ "}"]
 

--- a/lib/Feldspar/Compiler/Imperative/FromCore/NoInline.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/NoInline.hs
@@ -63,6 +63,6 @@ instance Compile dom dom => Compile (NoInline :|| Type) dom
         funId  <- freshId
         let funname = "noinline" ++ show funId
         tellDef [ProcDef funname ins outs b]
-        let ins' = map (\v -> In $ varToExpr $ Variable (typeof v) (vName v)) ins
-        tellProg [call funname $ ins' ++ [Out loc]]
+        let ins' = map (\v -> ValueParameter $ varToExpr $ Variable (typeof v) (vName v)) ins
+        tellProg [call funname $ ins' ++ [ValueParameter loc]]
 

--- a/lib/Feldspar/Compiler/Imperative/Representation.hs
+++ b/lib/Feldspar/Compiler/Imperative/Representation.hs
@@ -144,11 +144,8 @@ data Pattern t
      deriving (Typeable, Show, Eq)
 
 data ActualParameter t
-    = In
-        { inParam                   :: Expression t
-        }
-    | Out
-        { outParam                  :: Expression t
+    = ValueParameter
+        { valueParam                :: Expression t
         }
     | TypeParameter
         { typeParam                 :: Type
@@ -316,8 +313,7 @@ instance HasType (Expression t) where
 
 instance HasType (ActualParameter t) where
     type TypeOf (ActualParameter t) = Type
-    typeof In{..}            = typeof inParam
-    typeof Out{..}           = typeof outParam
+    typeof ValueParameter{..}= typeof valueParam
     typeof TypeParameter{..} = typeParam
     typeof FunParameter{}    = VoidType
 

--- a/lib/Feldspar/Compiler/Imperative/TransformationInstance.hs
+++ b/lib/Feldspar/Compiler/Imperative/TransformationInstance.hs
@@ -120,9 +120,7 @@ instance (Transformable1 t [] Program, Transformable t Expression, Transformable
 
 instance (Transformable t Expression, Default (Up t))
     => DefaultTransformable t ActualParameter where
-        defaultTransform t s d (In p) = Result (In (result tr)) (state tr) (up tr) where
-            tr = transform t s d p
-        defaultTransform t s d (Out p) = Result (Out (result tr)) (state tr) (up tr) where
+        defaultTransform t s d (ValueParameter p) = Result (ValueParameter (result tr)) (state tr) (up tr) where
             tr = transform t s d p
         defaultTransform _ s _ (TypeParameter p) = Result (TypeParameter p) s def
         defaultTransform _ s _ (FunParameter n) = Result (FunParameter n) s def


### PR DESCRIPTION
Nothing in the compiler uses the direction of parameters, and if that
need arises it should probably be a flag to the ValueParameter rather than
separate constructors.
