### PR TITLE
Defer the choice of array representation to further back in the backend.

### DIFF
--- a/lib/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore.hs
@@ -104,9 +104,8 @@ compileProgTop opt funname bs (lam :$ body)
          let ta  = argType $ infoType $ getInfo lam
              sa  = fst $ infoSize $ getInfo lam
              typ = compileTypeRep ta sa
-             arg = if isComposite typ
-                     then mkPointer  typ v
-                     else mkVariable typ v
+             arg | Rep.StructType{} <- typ = mkPointer typ v
+                 | otherwise               = mkVariable typ v
          tell $ mempty {args=[arg]}
          withAlias v (varToExpr arg) $
            compileProgTop opt funname bs body
@@ -122,7 +121,7 @@ compileProgTop opt funname bs (lt :$ e :$ (lam :$ body))
   where
     info     = getInfo e
     outType  = case compileTypeRep (infoType info) (infoSize info) of
-                 Rep.Pointer (Rep.ArrayType rs t) -> Rep.NativeArray (Just $ upperBound rs) t
+                 Rep.ArrayType rs t -> Rep.NativeArray (Just $ upperBound rs) t
                  t -> t
     var@(Rep.Variable _ freshName) = case prjLambda lam of
                Just (SubConstr2 (Lambda v)) -> mkVariable outType v

--- a/lib/Feldspar/Compiler/Imperative/FromCore/Interpretation.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/Interpretation.hs
@@ -274,8 +274,8 @@ compileTypeRep (Tup7Type a b c d e f g) (sa,sb,sc,sd,se,sf,sg) = mkStructType
         ]
 compileTypeRep (MutType a) _            = compileTypeRep a (defaultSize a)
 compileTypeRep (RefType a) _            = compileTypeRep a (defaultSize a)
-compileTypeRep (Core.ArrayType a) (rs :> es) = Pointer $ ArrayType rs $ compileTypeRep a es
-compileTypeRep (MArrType a) (rs :> es)  = Pointer $ ArrayType rs $ compileTypeRep a es
+compileTypeRep (Core.ArrayType a) (rs :> es) = ArrayType rs $ compileTypeRep a es
+compileTypeRep (MArrType a) (rs :> es)  = ArrayType rs $ compileTypeRep a es
 compileTypeRep (ParType a) _            = compileTypeRep a (defaultSize a)
 compileTypeRep (Core.IVarType a) _      = IVarType $ compileTypeRep a $ defaultSize a
 compileTypeRep (FunType _ b) (_, sz)    = compileTypeRep b sz
@@ -387,8 +387,8 @@ getTypes opts defs = concatMap mkDef comps
     mkDef _                 = []
 
 assign :: Location -> Expression () -> CodeWriter ()
-assign lhs rhs = tellProg [if lhs == rhs then Empty else copyProg lhs' [rhs]]
-  where lhs' = if (isArray $ typeof lhs) then AddrOf lhs else lhs
+assign lhs rhs = tellProg [if lhs == rhs then Empty else copyProg lhs [rhs]]
+
 -- | Like 'listen', but also prevents the program from being written in the
 -- monad.
 confiscateBlock :: CodeWriter a -> CodeWriter (a, Block ())

--- a/lib/Feldspar/Compiler/Imperative/FromCore/Mutable.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/Mutable.hs
@@ -114,26 +114,26 @@ instance (Compile dom dom, Project (CLambda Type) dom) => Compile MutableArray d
   where
     compileProgSym NewArr_ _ loc (len :* Nil) = do
       l <- compileExpr len
-      tellProg [initArray (AddrOf loc) l]
+      tellProg [initArray loc l]
 
     compileProgSym NewArr _ loc (len :* a :* Nil) = do
         nId <- freshId
         let ix = varToExpr $ mkNamedVar "i" (Rep.NumType Rep.Unsigned Rep.S32) nId
         a' <- compileExpr a
         l  <- compileExpr len
-        tellProg [initArray (AddrOf loc) l]
-        tellProg [for False "i" l 1 $ toBlock (Sequence [copyProg (ArrayElem (AddrOf loc) ix) [a']])]
+        tellProg [initArray loc l]
+        tellProg [for False "i" l 1 $ toBlock (Sequence [copyProg (ArrayElem loc ix) [a']])]
 
     compileProgSym GetArr _ loc (arr :* i :* Nil) = do
         arr' <- compileExpr arr
         i'   <- compileExpr i
-        assign loc (ArrayElem (AddrOf arr') i')
+        assign loc (ArrayElem arr' i')
 
     compileProgSym SetArr _ _ (arr :* i :* a :* Nil) = do
         arr' <- compileExpr arr
         i'   <- compileExpr i
         a'   <- compileExpr a
-        assign (ArrayElem (AddrOf arr') i') a'
+        assign (ArrayElem arr' i') a'
 
     compileProgSym a info loc args = compileExprLoc a info loc args
 

--- a/lib/Feldspar/Compiler/Imperative/FromCore/MutableToPure.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/MutableToPure.hs
@@ -84,7 +84,7 @@ instance ( Compile dom dom
         , Just NewArr_ <- prj na
         = do
             len <- compileExpr l
-            tellProg [setLength (AddrOf loc) len]
+            tellProg [setLength loc len]
             withAlias v loc $ compileProg loc body
 
     compileProgSym RunMutableArray _ loc (marr :* Nil) = compileProg loc marr

--- a/lib/Feldspar/Compiler/Imperative/Frontend.hs
+++ b/lib/Feldspar/Compiler/Imperative/Frontend.hs
@@ -91,7 +91,7 @@ initArray arr len = Assign arr $ fun (typeof arr) "initArray" [arr, sz, len]
     go _               = error $ "Feldspar.Compiler.Imperative.Frontend.initArray: invalid type of array " ++ show arr ++ "::" ++ show (typeof arr)
 
 freeArray :: Variable () -> Program ()
-freeArray arr = call "freeArray" [ValueParameter $ AddrOf $ varToExpr arr]
+freeArray arr = call "freeArray" [ValueParameter $ varToExpr arr]
 
 freeArrays :: [Declaration ()] -> [Program ()]
 freeArrays defs = map freeArray arrays
@@ -101,7 +101,7 @@ freeArrays defs = map freeArray arrays
 arrayLength :: Expression () -> Expression ()
 arrayLength arr
   | Just r <- chaseArray arr = litI32 $ fromIntegral (upperBound r)
-  | otherwise = FunctionCall (Function "getLength" (NumType Unsigned S32) Prefix) [AddrOf arr]
+  | otherwise = FunctionCall (Function "getLength" (NumType Unsigned S32) Prefix) [arr]
 
 chaseArray :: Expression t-> Maybe (Range Length)
 chaseArray e = go e []  -- TODO: Extend to handle x.member1.member2
@@ -123,14 +123,14 @@ iVarInit var = call "ivar_init" [ValueParameter var]
 
 iVarGet :: Expression () -> Expression () -> Program ()
 iVarGet loc ivar 
-    | isArray typ   = call "ivar_get_array" [ValueParameter $ AddrOf loc, ValueParameter ivar]
+    | isArray typ   = call "ivar_get_array" [ValueParameter loc, ValueParameter ivar]
     | otherwise     = call "ivar_get" [TypeParameter typ, ValueParameter loc, ValueParameter ivar]
       where
         typ = typeof loc
 
 iVarPut :: Expression () -> Expression () -> Program ()
 iVarPut ivar msg
-    | isArray typ   = call "ivar_put_array" [ValueParameter ivar, ValueParameter $ AddrOf msg]
+    | isArray typ   = call "ivar_put_array" [ValueParameter ivar, ValueParameter  msg]
     | otherwise     = call "ivar_put" [TypeParameter typ, ValueParameter ivar, ValueParameter msg]
       where
         typ = typeof msg

--- a/tests/gold/divConq3.c
+++ b/tests/gold/divConq3.c
@@ -48,7 +48,7 @@ void divConq3(struct array * v0, struct array * * out)
   {
     v23 = (v12 << 10);
     ivar_init(&at(struct ivar,v24,v12));
-    spawn5(task3, struct array, *v0, uint32_t, v22, uint32_t, v23, struct array, *v24, uint32_t, v12);
+    spawn5(task3, struct array *, v0, uint32_t, v22, uint32_t, v23, struct array *, v24, uint32_t, v12);
   }
   len4 = getLength(v24);
   *out = initArray(*out, sizeof(int32_t), 0);


### PR DESCRIPTION
This change makes arrays opaque to the compiler and lets the pretty printer
be concerned about the particular choice of array representation. As a side
effect it also simplifies code all over the place.

No functional changes.
