### PR TITLE
Maybe location

### DIFF
--- a/lib/Feldspar/Compiler/Backend/C/Platforms.hs
+++ b/lib/Feldspar/Compiler/Backend/C/Platforms.hs
@@ -138,13 +138,13 @@ arrayRules = [rule copy]
   where
     copy (ProcedureCall "copy" [ValueParameter arg1, ValueParameter arg2])
         | arg1 == arg2 = [replaceWith Empty]
-        | ConstExpr ArrayConst{..} <- arg2 = [replaceWith $ Sequence $ initArray arg1 (litI32 $ toInteger $ length arrayValues):zipWith (\i c -> Assign (ArrayElem arg1 (litI32 i)) (ConstExpr c)) [0..] arrayValues]
+        | ConstExpr ArrayConst{..} <- arg2 = [replaceWith $ Sequence $ initArray (Just arg1) (litI32 $ toInteger $ length arrayValues):zipWith (\i c -> Assign (ArrayElem arg1 (litI32 i)) (ConstExpr c)) [0..] arrayValues]
         | NativeArray{} <- typeof arg2
-        , l@(ConstExpr (IntConst n _)) <- arrayLength arg2 = [replaceWith $ Sequence $ initArray arg1 l:map (\i -> Assign (ArrayElem arg1 (litI32 i)) (ArrayElem arg2 (litI32 i))) [0..(n-1)]]
+        , l@(ConstExpr (IntConst n _)) <- arrayLength arg2 = [replaceWith $ Sequence $ initArray (Just arg1) l:map (\i -> Assign (ArrayElem arg1 (litI32 i)) (ArrayElem arg2 (litI32 i))) [0..(n-1)]]
         | not (isArray (typeof arg1)) = [replaceWith $ Assign arg1 arg2]
     copy (ProcedureCall "copy" (dst@(ValueParameter arg1):ins'@(ValueParameter in1:ins))) | isArray (typeof arg1)
         = [replaceWith $ Sequence ([
-               initArray arg1 (foldr ePlus (litI32 0) aLens)
+               initArray (Just arg1) (foldr ePlus (litI32 0) aLens)
              , if (arg1 == in1) then Empty else call "copyArray" [dst, ValueParameter in1]
              ] ++ flattenCopy dst ins argnLens arg1len)]
            where

--- a/lib/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore.hs
@@ -126,7 +126,7 @@ compileProgTop opt funname bs (lt :$ e :$ (lam :$ body))
     var@(Rep.Variable _ freshName) = case prjLambda lam of
                Just (SubConstr2 (Lambda v)) -> mkVariable outType v
     bd = sequenceProgs $ blockBody $ block $ snd $
-          evalRWS (compileProg (varToExpr var) e) (initReader opt) initState
+          evalRWS (compileProg (Just $ varToExpr var) e) (initReader opt) initState
 compileProgTop opt funname bs e@(lt :$ _ :$ _)
   | Just Let <- prj lt
   , (bs', body) <- collectLetBinders e
@@ -138,7 +138,7 @@ compileProgTop opt funname bs a = do
         outParam   = Rep.Variable outType "out"
         outLoc     = varToExpr outParam
     mapM compileBind (reverse bs)
-    compileProg outLoc a
+    compileProg (Just outLoc) a
     return outParam
 
 fromCore :: SyntacticFeld a => Options -> String -> a -> Module ()

--- a/lib/Feldspar/Compiler/Imperative/FromCore/Binding.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/Binding.hs
@@ -84,7 +84,7 @@ compileLet a info v
             sa  = infoSize $ getInfo a
             var = mkVar (compileTypeRep ta sa) v
         declare var
-        compileProg var a
+        compileProg (Just var) a
         return var
 
 compileBind :: Compile dom dom
@@ -94,4 +94,4 @@ compileBind (v, ASTB e)
          let info = getInfo e
              var = mkVar (compileTypeRep (infoType info) (infoSize info)) v
          declare var
-         compileProg var e
+         compileProg (Just var) e

--- a/lib/Feldspar/Compiler/Imperative/FromCore/Future.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/Future.hs
@@ -51,7 +51,7 @@ instance Compile dom dom => Compile (FUTURE :|| Type) dom
   where
     compileExprSym = compileProgFresh
 
-    compileProgSym (C' MkFuture) info loc (p :* Nil) = do
+    compileProgSym (C' MkFuture) info (Just loc) (p :* Nil) = do
         let args = [mkVariable (compileTypeRep t (defaultSize t)) v
                    | (v,SomeType t) <- assocs $ infoVars info
                    ] ++ fv loc
@@ -72,5 +72,5 @@ instance Compile dom dom => Compile (FUTURE :|| Type) dom
 
     compileProgSym (C' Await) _ loc (a :* Nil) = do
         fut <- compileExprVar a -- compileExpr a
-        tellProg [iVarGet loc fut]
+        tellProg [iVarGet l fut | Just l <- [loc]]
 

--- a/lib/Feldspar/Compiler/Imperative/FromCore/Mutable.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/Mutable.hs
@@ -35,6 +35,7 @@
 module Feldspar.Compiler.Imperative.FromCore.Mutable where
 
 
+import Control.Applicative
 
 import Language.Syntactic
 import Language.Syntactic.Constructs.Binding
@@ -68,11 +69,11 @@ instance ( Compile dom dom
             let info = getInfo ma
                 var  = mkVar (compileTypeRep (infoType info) (infoSize info)) v
             declare var
-            compileProg var ma
+            compileProg (Just var) ma
             compileProg loc body
 
     compileProgSym Then _ loc (ma :* mb :* Nil) = do
-        _ <- compileExpr ma
+        compileProg Nothing ma
         compileProg loc mb
 
     compileProgSym Return info loc (a :* Nil)
@@ -96,12 +97,12 @@ instance (Compile dom dom, Project (CLambda Type) dom) => Compile MutableReferen
     compileProgSym GetRef _ loc (r :* Nil) = compileProg loc r
     compileProgSym SetRef _ _   (r :* a :* Nil) = do
         var  <- compileExpr r
-        compileProg var a
+        compileProg (Just var) a
     compileProgSym ModRef _ loc (r :* (lam :$ body) :* Nil)
         | Just (SubConstr2 (Lambda v)) <- prjLambda lam
         = do
             var <- compileExpr r
-            withAlias v var $ compileProg var body
+            withAlias v var $ compileProg (Just var) body
                -- Since the modifier function is pure it is safe to alias
                -- v with var here
 
@@ -120,7 +121,7 @@ instance (Compile dom dom, Project (CLambda Type) dom) => Compile MutableArray d
         a' <- compileExpr a
         l  <- compileExpr len
         tellProg [initArray loc l]
-        tellProg [for False "i" l 1 $ toBlock (Sequence [copyProg (ArrayElem loc ix) [a']])]
+        tellProg [for False "i" l 1 $ toBlock (Sequence [copyProg (ArrayElem <$> loc <*> pure ix) [a']])]
 
     compileProgSym GetArr _ loc (arr :* i :* Nil) = do
         arr' <- compileExpr arr
@@ -131,7 +132,7 @@ instance (Compile dom dom, Project (CLambda Type) dom) => Compile MutableArray d
         arr' <- compileExpr arr
         i'   <- compileExpr i
         a'   <- compileExpr a
-        assign (ArrayElem arr' i') a'
+        assign (Just $ ArrayElem arr' i') a'
 
     compileProgSym a info loc args = compileExprLoc a info loc args
 

--- a/lib/Feldspar/Compiler/Imperative/FromCore/MutableToPure.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/MutableToPure.hs
@@ -75,17 +75,17 @@ instance ( Compile dom dom
             let sa = fst $ infoSize $ getInfo lam
             let var = mkVar (compileTypeRep ta sa) v
             declare var
-            compileProg var marr
+            compileProg (Just var) marr
             e <- compileExpr body
             tellProg [copyProg loc [e]]
 
-    compileProgSym RunMutableArray _ loc ((bnd :$ (na :$ l) :$ (lam :$ body)) :* Nil)
+    compileProgSym RunMutableArray _ (Just loc) ((bnd :$ (na :$ l) :$ (lam :$ body)) :* Nil)
         | Just (SubConstr2 (Lambda v)) <- prjLambda lam
         , Just NewArr_ <- prj na
         = do
             len <- compileExpr l
             tellProg [setLength loc len]
-            withAlias v loc $ compileProg loc body
+            withAlias v loc $ compileProg (Just loc) body
 
     compileProgSym RunMutableArray _ loc (marr :* Nil) = compileProg loc marr
 

--- a/lib/Feldspar/Compiler/Imperative/FromCore/NoInline.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/NoInline.hs
@@ -53,11 +53,11 @@ instance Compile dom dom => Compile (NoInline :|| Type) dom
   where
     compileExprSym = compileProgFresh
 
-    compileProgSym (C' NoInline) info loc (p :* Nil) = do
+    compileProgSym (C' NoInline) info (Just loc) (p :* Nil) = do
         let args = [mkVariable (compileTypeRep t (defaultSize t)) v
                    | (v,SomeType t) <- assocs $ infoVars info
                    ]
-        (_, b)  <- confiscateBlock $ compileProg loc p
+        (_, b)  <- confiscateBlock $ compileProg (Just loc) p
         let isInParam v = vName v /= lName loc
         let (ins,outs) = partition isInParam args
         funId  <- freshId

--- a/lib/Feldspar/Compiler/Imperative/FromCore/Tuple.hs
+++ b/lib/Feldspar/Compiler/Imperative/FromCore/Tuple.hs
@@ -35,6 +35,7 @@
 module Feldspar.Compiler.Imperative.FromCore.Tuple where
 
 
+import Control.Applicative
 
 import Language.Syntactic
 
@@ -50,38 +51,38 @@ import Feldspar.Compiler.Imperative.FromCore.Interpretation
 instance Compile dom dom => Compile (Tuple :|| Type) dom
   where
     compileProgSym (C' Tup2) _ loc (m1 :* m2 :* Nil) = do
-        compileProg (StructField loc "member1") m1
-        compileProg (StructField loc "member2") m2
+        compileProg (StructField <$> loc <*> pure "member1") m1
+        compileProg (StructField <$> loc <*> pure "member2") m2
     compileProgSym (C' Tup3) _ loc (m1 :* m2 :* m3 :* Nil) = do
-        compileProg (StructField loc "member1") m1
-        compileProg (StructField loc "member2") m2
-        compileProg (StructField loc "member3") m3
+        compileProg (StructField <$> loc <*> pure "member1") m1
+        compileProg (StructField <$> loc <*> pure "member2") m2
+        compileProg (StructField <$> loc <*> pure "member3") m3
     compileProgSym (C' Tup4) _ loc (m1 :* m2 :* m3 :* m4 :* Nil) = do
-        compileProg (StructField loc "member1") m1
-        compileProg (StructField loc "member2") m2
-        compileProg (StructField loc "member3") m3
-        compileProg (StructField loc "member4") m4
+        compileProg (StructField <$> loc <*> pure "member1") m1
+        compileProg (StructField <$> loc <*> pure "member2") m2
+        compileProg (StructField <$> loc <*> pure "member3") m3
+        compileProg (StructField <$> loc <*> pure "member4") m4
     compileProgSym (C' Tup5) _ loc (m1 :* m2 :* m3 :* m4 :* m5 :* Nil) = do
-        compileProg (StructField loc "member1") m1
-        compileProg (StructField loc "member2") m2
-        compileProg (StructField loc "member3") m3
-        compileProg (StructField loc "member4") m4
-        compileProg (StructField loc "member5") m5
+        compileProg (StructField <$> loc <*> pure "member1") m1
+        compileProg (StructField <$> loc <*> pure "member2") m2
+        compileProg (StructField <$> loc <*> pure "member3") m3
+        compileProg (StructField <$> loc <*> pure "member4") m4
+        compileProg (StructField <$> loc <*> pure "member5") m5
     compileProgSym (C' Tup6) _ loc (m1 :* m2 :* m3 :* m4 :* m5 :* m6 :* Nil) = do
-        compileProg (StructField loc "member1") m1
-        compileProg (StructField loc "member2") m2
-        compileProg (StructField loc "member3") m3
-        compileProg (StructField loc "member4") m4
-        compileProg (StructField loc "member5") m5
-        compileProg (StructField loc "member6") m6
+        compileProg (StructField <$> loc <*> pure "member1") m1
+        compileProg (StructField <$> loc <*> pure "member2") m2
+        compileProg (StructField <$> loc <*> pure "member3") m3
+        compileProg (StructField <$> loc <*> pure "member4") m4
+        compileProg (StructField <$> loc <*> pure "member5") m5
+        compileProg (StructField <$> loc <*> pure "member6") m6
     compileProgSym (C' Tup7) _ loc (m1 :* m2 :* m3 :* m4 :* m5 :* m6 :* m7 :* Nil) = do
-        compileProg (StructField loc "member1") m1
-        compileProg (StructField loc "member2") m2
-        compileProg (StructField loc "member3") m3
-        compileProg (StructField loc "member4") m4
-        compileProg (StructField loc "member5") m5
-        compileProg (StructField loc "member6") m6
-        compileProg (StructField loc "member7") m7
+        compileProg (StructField <$> loc <*> pure "member1") m1
+        compileProg (StructField <$> loc <*> pure "member2") m2
+        compileProg (StructField <$> loc <*> pure "member3") m3
+        compileProg (StructField <$> loc <*> pure "member4") m4
+        compileProg (StructField <$> loc <*> pure "member5") m5
+        compileProg (StructField <$> loc <*> pure "member6") m6
+        compileProg (StructField <$> loc <*> pure "member7") m7
 
 instance Compile dom dom => Compile (Select :|| Type) dom
   where

--- a/lib/Feldspar/Compiler/Imperative/Frontend.hs
+++ b/lib/Feldspar/Compiler/Imperative/Frontend.hs
@@ -72,15 +72,17 @@ setLength arr len = Assign arr $ fun (typeof arr) "setLength" [arr, sz, len]
 
 -- | Copies expressions into a destination. If the destination is
 -- a non-scalar the arguments are appended to the destination.
-copyProg :: Expression ()-> [Expression ()] -> Program ()
+copyProg :: Maybe (Expression ())-> [Expression ()] -> Program ()
 copyProg _ [] = error "copyProg: missing source parameter."
-copyProg outExp inExp
+copyProg Nothing _ = Empty
+copyProg (Just outExp) inExp
     | outExp == head inExp
       && null (tail inExp) = Empty
     | otherwise            = call "copy" (ValueParameter outExp:map ValueParameter inExp)
 
-initArray :: Expression () -> Expression () -> Program ()
-initArray arr len = Assign arr $ fun (typeof arr) "initArray" [arr, sz, len]
+initArray :: Maybe (Expression ()) -> Expression () -> Program ()
+initArray Nothing _      = Empty
+initArray (Just arr) len = Assign arr $ fun (typeof arr) "initArray" [arr, sz, len]
   where
     sz | isArray t' = binop (NumType Unsigned S32) "-" (litI32 0) t
        | otherwise  = t


### PR DESCRIPTION
Please review, @emilaxelsson, @josefs, @pjonsson.
# Background

In Feldspar/feldspar-language the following code

``` haskell
do
    _ <- m1
    m2
```

results in the following syntax tree

```
bind
  |
  +- m1
  |
  +- lambda x
        |
        +- m2
```

Since `x` does not appear in `m2` it is rewritten to

```
then
  |
  +- m1
  |
  +- m2
```
# Problem

Currently, the compiler issues an error message if `m1` will actually write to the location `x`.
https://github.com/Feldspar/feldspar-compiler/blob/master/lib/Feldspar/Compiler/Imperative/FromCore/Mutable.hs#L75-77
# Solution

Change the type of `Location` to `Maybe (Expression ())` so that a location can be nullable.
If the `Location` is `Nothing`, the parts of the program writing to it will not be generated.
