### PR TITLE
Bump GHC and Alex version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,18 @@ cache:
 matrix:
   include:
     - env: CABALVER=1.18 GHCVER=7.8.4
-      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.4]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-1.22,ghc-7.10.2,happy-1.19.5,alex-3.1.4]}}
+      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-1.18,ghc-7.8.4,happy-1.19.5,alex-3.1.7]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7]}}
     - env: CABALVER=head GHCVER=head
-      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.4]}}
+      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7]}}
 
   allow_failures:
     - env: CABALVER=head GHCVER=head
 
 before_install:
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+  - export PATH=/opt/alex/3.1.7/bin:/opt/happy/1.19.5/bin:$PATH
   - env
   # Fetch the latest feldspar-language from github
   # Note that we will fetch a branch with the same name as the current
@@ -29,8 +31,6 @@ before_install:
   - cd $TRAVIS_BUILD_DIR
 
 install:
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
-  - export PATH=/opt/alex/3.1.4/bin:/opt/happy/1.19.5/bin:$PATH
   - cabal --version
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - travis_retry cabal update


### PR DESCRIPTION
Bump GHC version to 7.10.3 to avoid cabal
inconsistency midway through the test in
Travis. Also bump the Alex version to a
more recent version.